### PR TITLE
Change Method names to industry standard

### DIFF
--- a/src/http/HttpMethod.hx
+++ b/src/http/HttpMethod.hx
@@ -1,10 +1,10 @@
 package http;
 
 enum abstract HttpMethod(String) from String to String {
-    var Get = "get";
-    var Post = "post";
-    var Put = "put";
-    var Patch = "patch";
-    var Delete = "delete";
-    var Options = "options";
+	var Get = "GET";
+	var Post = "POST";
+	var Put = "PUT";
+	var Patch = "PATCH";
+	var Delete = "DELETE";
+	var Options = "OPTIONS";
 }


### PR DESCRIPTION
The api i use seems to require the names in the uppercase form